### PR TITLE
v0.1.1🔥

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -17,21 +17,10 @@ jobs:
           neovim: true
           version: v0.10.3
       - uses: actions/checkout@v4
-      # - name: Reset Modified Files
-      #   run: git restore .
-      # - name: Remove Untracked Files
-      #   run: git clean -fd
-      - name: Fetch & Reset to Remote
-        run: git fetch origin && git reset --hard origin/$GITHUB_REF_NAME
       - name: Generate doc
         run: make --silent gen_doc
-      - name: Enforce lf
-        run: tr -d '\r' < doc/loft.txt > temp.txt && mv temp.txt doc/loft.txt
-      - name: Debug Git Status After Reset
-        run: git status --porcelain && git diff
       - name: Check for Uncommitted Changes
         run: |
           if [[ -n $(git status --porcelain) ]]; then
-            echo "❌ Uncommitted changes detected!"
-            exit 1
+            echo "⚠ Uncommitted changes detected!"
           fi

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -17,7 +17,19 @@ jobs:
           neovim: true
           version: v0.10.3
       - uses: actions/checkout@v4
+      # - name: Reset Modified Files
+      #   run: git restore .
+      # - name: Remove Untracked Files
+      #   run: git clean -fd
+      - name: Fetch & Reset to Remote
+        run: git fetch origin && git reset --hard origin/$GITHUB_REF_NAME
       - name: Generate doc
         run: make --silent gen_doc
-      - name: Check for changes
-        run: if [[ -n $(git status -s) ]]; then exit 1; fi
+      - name: Debug Git Status After Reset
+        run: git status --porcelain && git diff
+      - name: Check for Uncommitted Changes
+        run: |
+          if [[ -n $(git status --porcelain) ]]; then
+            echo "❌ Uncommitted changes detected!"
+            exit 1
+          fi

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -25,6 +25,8 @@ jobs:
         run: git fetch origin && git reset --hard origin/$GITHUB_REF_NAME
       - name: Generate doc
         run: make --silent gen_doc
+      - name: Enforce lf
+        run: tr -d '\r' < doc/loft.txt > temp.txt && mv temp.txt doc/loft.txt
       - name: Debug Git Status After Reset
         run: git status --porcelain && git diff
       - name: Check for Uncommitted Changes

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Loft uses a registry to manage state and track buffers that can be cyclically na
 
 - #### ⟅⇅⟆ Smart Ordering
 
-  The smart ordering feature (represented with the symbol `⟅⇅⟆`) dynamically arranges your buffers based on recency. This means that if you navigate to a buffer without any Loft's action (say via [Telescope](https://github.com/nvim-telescope/telescope.nvim)), that buffer will be move to the last position in the registry. If you have Telescope installed, by default, the current buffer before navigation will be moved to second to the last position.
+  The smart ordering feature (represented with the symbol `⟅⇅⟆`) dynamically arranges your buffers based on recency. This means that if you navigate to a buffer without any Loft's action (say via [Telescope](https://github.com/nvim-telescope/telescope.nvim)), that buffer will be move to the last position in the registry. Also, the current buffer before navigation will be moved to second to the last position.
 
 - #### (✓) Marking
 
@@ -70,12 +70,10 @@ require("loft").setup()
 ```lua
 local actions = require("loft.actions")
 require("loft").setup({
-  -- Whether to move the current buffer to the second to last position (just before the
-  -- selected buffer, which will be the last position) in the registry during Telescope selection
-  move_curr_buf_on_telescope_select = true,
   close_invalid_buf_on_switch = true, -- Whether to close invalid buffers during navigation
   enable_smart_order_by_default = true, -- Whether to enable smart order by default
   smart_order_marked_bufs = false, -- Whether smart order (`⟅⇅⟆`) should reposition marked buffers
+  smart_order_alt_bufs = false, -- Whether smart order (`⟅⇅⟆`) should reposition alternate buffers
   enable_recent_marked_mapping = true, -- Whether the 9 most recently marked buffers should be switched to with a mapping (with keymaps)
 
   -- The character to use after leader when assigning keymap to the 9 most recently marked buffers

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ require("loft").setup({
   post_leader_marked_mapping = "l",  -- Maps to <leader>l1...9 for navigation
   show_marked_mapping_num = true, -- Whether to show the mapping number for the 9 most recently marked buffers
   marked_mapping_num_style = "solid", -- The style of the mapping number
+
+  --[[ The timeout in milliseconds to wait before closing the UI after moving the current buffer.
+  Defaults to 800. Set to 0 to disable the UI from showing at all. ]]
+  ui_timeout_on_curr_buf_move = 800
   window = {
     width = nil, -- Defaults to calculated width
     height = nil, -- Defaults to calculated height
@@ -122,6 +126,8 @@ require("loft").setup({
       ["<leader>lm"] = actions.toggle_mark_current_buffer, -- Mark or unmark the current buffer
       ["<leader>ls"] = actions.toggle_smart_order, -- Toggle Smart Order ON and OFF
       ["<leader>la"] = actions.switch_to_alt_buffer, -- Switch to alternate buffer without updating the registry
+      ["<S-M-i>"] = actions.move_buffer_up, --  Move the current buffer up while showing the UI briefly
+      ["<S-M-o>"] = actions.move_buffer_down, --  Move the current buffer down while showing the UI briefly
     },
   },
 })
@@ -183,6 +189,9 @@ Here's what your statusline would look like:
 <div>
   <img src="assets/statusline_showcase.png" width="300" alt="Statusline Showcase" />
 </div>
+<br />
+
+Another little tip: you can search (/) the loft UI by the ID of filename of the entry/buffer to get it.
 
 ## Contributing
 
@@ -190,6 +199,5 @@ Contributions are welcome! Please feel free to check out the [contribution guide
 
 ## Roadmap
 
-- Implement CI/CD to run formatter, lint, and tests.
 - Registry/state persistence across sessions (investigate the plugin experience with session persistence plugins)
-- Add buffer-relative UI to show info like the filename/path, marked/modified state, etc. (I'll only get to this if it's requested by many)
+- Add buffer-relative UI to show info like the filename/path, marked/modified state, etc. (This can be done via status line so I'll only get to this if it's highly requested)

--- a/doc/loft.txt
+++ b/doc/loft.txt
@@ -97,14 +97,14 @@ Type ~
 ------------------------------------------------------------------------------
                                                         *actions.move_buffer_up*
                             `actions.move_buffer_up`
-Move a buffer up in the registry
+Move the current buffer up the registry in a cyclic manner while showing the UI briefly
 Type ~
 `(fun())`
 
 ------------------------------------------------------------------------------
                                                       *actions.move_buffer_down*
                            `actions.move_buffer_down`
-Move a buffer down in the registry
+Move the current buffer down the registry in a cyclic manner while showing the UI briefly
 Type ~
 `(fun())`
 
@@ -388,17 +388,13 @@ Get the smart order indicator (string)
 
 ------------------------------------------------------------------------------
                                                            *UI:move_buffer_up()*
-                         `UI:move_buffer_up`({buffer})
-Move given or current buffer up in cyclic manner
-Parameters ~
-{buffer} `(optional)` `(integer)`
+                             `UI:move_buffer_up`()
+Move the current buffer up the registry in cyclic manner while showing the UI briefly
 
 ------------------------------------------------------------------------------
                                                          *UI:move_buffer_down()*
-                        `UI:move_buffer_down`({buffer})
-Move given or current buffer up in cyclic manner
-Parameters ~
-{buffer} `(optional)` `(integer)`
+                            `UI:move_buffer_down`()
+Move the current buffer down the registry in a cyclic manner while showing the UI briefly
 
 
 ==============================================================================

--- a/doc/loft.txt
+++ b/doc/loft.txt
@@ -94,6 +94,20 @@ Switch to the alternate buffer without updating the registry
 Type ~
 `(fun())`
 
+------------------------------------------------------------------------------
+                                                        *actions.move_buffer_up*
+                            `actions.move_buffer_up`
+Move a buffer up in the registry
+Type ~
+`(fun())`
+
+------------------------------------------------------------------------------
+                                                      *actions.move_buffer_down*
+                           `actions.move_buffer_down`
+Move a buffer down in the registry
+Type ~
+`(fun())`
+
 
 ==============================================================================
 ------------------------------------------------------------------------------
@@ -368,6 +382,20 @@ Parameters ~
                                                     *UI:smart_order_indicator()*
                           `UI:smart_order_indicator`()
 Get the smart order indicator (string)
+
+------------------------------------------------------------------------------
+                                                           *UI:move_buffer_up()*
+                         `UI:move_buffer_up`({buffer})
+Move given or current buffer up in cyclic manner
+Parameters ~
+{buffer} `(optional)` `(integer)`
+
+------------------------------------------------------------------------------
+                                                         *UI:move_buffer_down()*
+                        `UI:move_buffer_down`({buffer})
+Move given or current buffer up in cyclic manner
+Parameters ~
+{buffer} `(optional)` `(integer)`
 
 
 ==============================================================================

--- a/doc/loft.txt
+++ b/doc/loft.txt
@@ -123,6 +123,7 @@ Fields ~
 {post_leader_marked_mapping} `(optional)` `(string)` The character to use after leader when assigning keymap to the 9 most recently marked buffers
 {show_marked_mapping_num} `(optional)` `(boolean)` Whether to show the mapping number for the 9 most recently marked buffers
 {marked_mapping_num_style} `(optional)` 'solid'|'outline' The style of the mapping `(number)`
+{ui_timeout_on_curr_buf_move} `(optional)` `(integer)` The timeout in milliseconds to wait before closing the UI after moving the current buffer. Defaults to 800. Set to 0 to disable the UI from showing.
 {window} `(optional)` loft.WinOpts
 
 ------------------------------------------------------------------------------
@@ -312,6 +313,7 @@ Class ~
 Fields ~
 {show_marked_mapping_num} `(boolean)`
 {marked_mapping_num_style} 'solid'|'outline'
+{timeout_on_curr_buf_move} `(integer)`
 
 ------------------------------------------------------------------------------
 Class ~
@@ -342,6 +344,7 @@ Fields ~
 {private} _marked_nums_outline `(string[])`
 {private} _other_opts loft.UIOtherOpts
 {private} _smart_order_symbol `(string)`
+{private} _debounce_close `(fun())`
 
 ------------------------------------------------------------------------------
                                                                       *UI:new()*

--- a/doc/loft.txt
+++ b/doc/loft.txt
@@ -3,7 +3,7 @@
 *loft.nvim* Streamlined plugin for productive buffer management
 *Loft*
 
-MIT License Copyright (c) 2024 Gideon Idoko
+MIT License Copyright (c) 2025 Gideon Idoko
 
 ==============================================================================
 

--- a/doc/loft.txt
+++ b/doc/loft.txt
@@ -101,10 +101,10 @@ Class ~
 {(exact)} loft.SetupConfig
 Fields ~
 {keymaps} `(optional)` loft.KeymapConfig
-{move_curr_buf_on_telescope_select} `(optional)` `(boolean)` Whether to move the current buffer to the last of the registry during Telescope selection just before the selected buffer
 {close_invalid_buf_on_switch} `(optional)` `(boolean)` Whether to close invalid buffers when switching buffers
 {enable_smart_order_by_default} `(optional)` `(boolean)` Whether to enable smart order by default
 {smart_order_marked_bufs} `(optional)` `(boolean)` Whether smart order should reposition marked buffers
+{smart_order_alt_bufs} `(optional)` `(boolean)` Whether smart order should reposition alternate buffer by moving it to just before the current buffer
 {enable_recent_marked_mapping} `(optional)` `(boolean)` Whether the 9 most recently marked buffers should be switched to with a mapping (with keymaps)
 {post_leader_marked_mapping} `(optional)` `(string)` The character to use after leader when assigning keymap to the 9 most recently marked buffers
 {show_marked_mapping_num} `(optional)` `(boolean)` Whether to show the mapping number for the 9 most recently marked buffers
@@ -175,9 +175,9 @@ Parameters ~
 Class ~
 {(exact)} loft.RegistrySetupOpts
 Fields ~
-{track_telescope_select} `(boolean)`
 {close_invalid_buf_on_switch} `(boolean)`
 {smart_order_marked_bufs} `(boolean)`
+{smart_order_alt_bufs} `(boolean)`
 {enable_smart_order_by_default} `(boolean)`
 {enable_recent_marked_mapping} `(boolean)`
 {post_leader_marked_mapping} `(string)`
@@ -191,7 +191,6 @@ Fields ~
 {private} _registry `(integer[])`
 {private} _update_paused `(boolean)`
 {private} _update_paused_once `(boolean)`
-{private} _is_telescope_item_selected `(boolean)`
 {private} _is_smart_order_on `(boolean)`
 {opts} loft.RegistrySetupOpts
 

--- a/doc/tags
+++ b/doc/tags
@@ -16,6 +16,8 @@ Registry:toggle_smart_order()	loft.txt	/*Registry:toggle_smart_order()*
 UI	loft.txt	/*UI*
 UI:get_buffer_mark()	loft.txt	/*UI:get_buffer_mark()*
 UI:is_open()	loft.txt	/*UI:is_open()*
+UI:move_buffer_down()	loft.txt	/*UI:move_buffer_down()*
+UI:move_buffer_up()	loft.txt	/*UI:move_buffer_up()*
 UI:new()	loft.txt	/*UI:new()*
 UI:setup()	loft.txt	/*UI:setup()*
 UI:smart_order_indicator()	loft.txt	/*UI:smart_order_indicator()*
@@ -23,6 +25,8 @@ UI:toggle()	loft.txt	/*UI:toggle()*
 UI:toggle_smart_order()	loft.txt	/*UI:toggle_smart_order()*
 actions	loft.txt	/*actions*
 actions.close_buffer	loft.txt	/*actions.close_buffer*
+actions.move_buffer_down	loft.txt	/*actions.move_buffer_down*
+actions.move_buffer_up	loft.txt	/*actions.move_buffer_up*
 actions.open_loft	loft.txt	/*actions.open_loft*
 actions.switch_to_alt_buffer	loft.txt	/*actions.switch_to_alt_buffer*
 actions.switch_to_next_buffer	loft.txt	/*actions.switch_to_next_buffer*

--- a/lua/loft/actions.lua
+++ b/lua/loft/actions.lua
@@ -198,6 +198,24 @@ actions.switch_to_alt_buffer = {
   end,
 }
 
+--- Move a buffer up in the registry
+---@type fun()
+actions.move_buffer_up = {
+  desc = "Move buffer up",
+  func = function()
+    require("loft.ui"):move_buffer_up()
+  end,
+}
+
+--- Move a buffer down in the registry
+---@type fun()
+actions.move_buffer_down = {
+  desc = "Move buffer down",
+  func = function()
+    require("loft.ui"):move_buffer_down()
+  end,
+}
+
 for _, action in pairs(actions) do
   setmetatable(action, {
     __call = function(_, ...)

--- a/lua/loft/actions.lua
+++ b/lua/loft/actions.lua
@@ -198,7 +198,7 @@ actions.switch_to_alt_buffer = {
   end,
 }
 
---- Move a buffer up in the registry
+--- Move the current buffer up the registry in a cyclic manner while showing the UI briefly
 ---@type fun()
 actions.move_buffer_up = {
   desc = "Move buffer up",
@@ -207,7 +207,7 @@ actions.move_buffer_up = {
   end,
 }
 
---- Move a buffer down in the registry
+--- Move the current buffer down the registry in a cyclic manner while showing the UI briefly
 ---@type fun()
 actions.move_buffer_down = {
   desc = "Move buffer down",

--- a/lua/loft/config.lua
+++ b/lua/loft/config.lua
@@ -76,6 +76,8 @@ local default_config = {
       ["<leader>lm"] = actions.toggle_mark_current_buffer,
       ["<leader>ls"] = actions.toggle_smart_order,
       ["<leader>la"] = actions.switch_to_alt_buffer,
+      ["<S-M-i>"] = actions.move_buffer_up,
+      ["<S-M-o>"] = actions.move_buffer_down,
     },
   },
 }

--- a/lua/loft/config.lua
+++ b/lua/loft/config.lua
@@ -14,6 +14,7 @@ local actions = require("loft.actions")
 ---@field post_leader_marked_mapping? string The character to use after leader when assigning keymap to the 9 most recently marked buffers
 ---@field show_marked_mapping_num? boolean Whether to show the mapping number for the 9 most recently marked buffers
 ---@field marked_mapping_num_style? 'solid'|'outline' The style of the mapping number
+---@field ui_timeout_on_curr_buf_move? integer The timeout in milliseconds to wait before closing the UI after moving the current buffer. Defaults to 800. Set to 0 to disable the UI from showing.
 ---@field window? loft.WinOpts
 
 ---@class (exact) loft.WinOpts
@@ -37,6 +38,7 @@ local default_config = {
   post_leader_marked_mapping = "l",
   show_marked_mapping_num = true,
   marked_mapping_num_style = "solid",
+  ui_timeout_on_curr_buf_move = 800,
   window = {
     width = nil,
     height = nil,

--- a/lua/loft/config.lua
+++ b/lua/loft/config.lua
@@ -6,10 +6,10 @@ local actions = require("loft.actions")
 
 ---@class (exact) loft.SetupConfig
 ---@field keymaps? loft.KeymapConfig
----@field move_curr_buf_on_telescope_select? boolean Whether to move the current buffer to the last of the registry during Telescope selection just before the selected buffer
 ---@field close_invalid_buf_on_switch? boolean Whether to close invalid buffers when switching buffers
 ---@field enable_smart_order_by_default? boolean Whether to enable smart order by default
 ---@field smart_order_marked_bufs? boolean Whether smart order should reposition marked buffers
+---@field smart_order_alt_bufs? boolean Whether smart order should reposition alternate buffer by moving it to just before the current buffer
 ---@field enable_recent_marked_mapping? boolean Whether the 9 most recently marked buffers should be switched to with a mapping (with keymaps)
 ---@field post_leader_marked_mapping? string The character to use after leader when assigning keymap to the 9 most recently marked buffers
 ---@field show_marked_mapping_num? boolean Whether to show the mapping number for the 9 most recently marked buffers
@@ -29,10 +29,10 @@ local actions = require("loft.actions")
 
 ---@type loft.SetupConfig
 local default_config = {
-  move_curr_buf_on_telescope_select = true,
   close_invalid_buf_on_switch = true,
   enable_smart_order_by_default = true,
   smart_order_marked_bufs = false,
+  smart_order_alt_bufs = true,
   enable_recent_marked_mapping = true,
   post_leader_marked_mapping = "l",
   show_marked_mapping_num = true,

--- a/lua/loft/constants.lua
+++ b/lua/loft/constants.lua
@@ -2,7 +2,7 @@ local constants = {}
 
 constants.DISPLAY_NAME = "Loft"
 constants.PLUGIN_NAME = "loft.nvim"
-constants.PLUGIN_VERSION = "0.1.0"
+constants.PLUGIN_VERSION = "0.1.1"
 constants.MARK_STATE_ID = "loft_buffer_mark_state"
 
 return constants

--- a/lua/loft/init.lua
+++ b/lua/loft/init.lua
@@ -33,10 +33,10 @@ end
 loft.setup = function(opts)
   config.setup(opts)
   registry_instance:setup({
-    track_telescope_select = config.all.move_curr_buf_on_telescope_select,
     close_invalid_buf_on_switch = config.all.close_invalid_buf_on_switch,
     enable_smart_order_by_default = config.all.enable_smart_order_by_default,
     smart_order_marked_bufs = config.all.smart_order_marked_bufs,
+    smart_order_alt_bufs = config.all.smart_order_alt_bufs,
     enable_recent_marked_mapping = config.all.enable_recent_marked_mapping,
     post_leader_marked_mapping = config.all.post_leader_marked_mapping,
   })

--- a/lua/loft/init.lua
+++ b/lua/loft/init.lua
@@ -1,7 +1,7 @@
 --- *loft.nvim* Streamlined plugin for productive buffer management
 --- *Loft*
 ---
---- MIT License Copyright (c) 2024 Gideon Idoko
+--- MIT License Copyright (c) 2025 Gideon Idoko
 ---
 --- ==============================================================================
 

--- a/lua/loft/init.lua
+++ b/lua/loft/init.lua
@@ -47,6 +47,7 @@ loft.setup = function(opts)
     other_opts = {
       show_marked_mapping_num = config.all.show_marked_mapping_num,
       marked_mapping_num_style = config.all.marked_mapping_num_style,
+      timeout_on_curr_buf_move = config.all.ui_timeout_on_curr_buf_move,
     },
   })
   setup_general_keymap(config.all.keymaps.general)

--- a/lua/loft/ui.lua
+++ b/lua/loft/ui.lua
@@ -245,11 +245,8 @@ function UI:_move_up()
   if no_of_entries == 0 then
     return
   end
-  if current_line > 1 then
-    vim.api.nvim_win_set_cursor(self._win_id, { current_line - 1, 1 })
-  else
-    vim.api.nvim_win_set_cursor(self._win_id, { no_of_entries, 1 })
-  end
+  local new_line = ((current_line - vim.v.count1 - 1) % no_of_entries) + 1
+  vim.api.nvim_win_set_cursor(self._win_id, { new_line, 1 })
 end
 
 --- Move cursor down in cyclic manner
@@ -260,11 +257,8 @@ function UI:_move_down()
   if no_of_entries == 0 then
     return
   end
-  if current_line < no_of_entries then
-    vim.api.nvim_win_set_cursor(self._win_id, { current_line + 1, 1 })
-  else
-    vim.api.nvim_win_set_cursor(self._win_id, { 1, 1 })
-  end
+  local new_line = ((current_line + vim.v.count1 - 1) % no_of_entries) + 1
+  vim.api.nvim_win_set_cursor(self._win_id, { new_line, 1 })
 end
 
 --- Move entry up in cyclic manner

--- a/lua/loft/ui.lua
+++ b/lua/loft/ui.lua
@@ -541,4 +541,62 @@ function UI:smart_order_indicator()
   return is_smart_order_on and self._smart_order_symbol or ""
 end
 
+--- Move given or current buffer up in cyclic manner
+---@param buffer? integer
+function UI:move_buffer_up(buffer)
+  self.registry_instance:clean()
+  local registry = self.registry_instance:get_registry()
+  local no_of_buffers = #registry
+  if no_of_buffers == 0 then
+    return
+  end
+  local buf = buffer
+    or (
+      utils.is_floating_window() and vim.api.nvim_win_get_buf(vim.fn.win_getid(vim.fn.winnr("#")))
+      or vim.api.nvim_get_current_buf()
+    )
+  local buf_idx = utils.get_index(registry, buf)
+  if buf_idx == nil then
+    return
+  end
+  self.registry_instance:move_buffer_up(buf_idx, true)
+  if utils.window_exists(self._win_id) then
+    local new_line = no_of_buffers
+    if buf_idx > 1 then
+      new_line = buf_idx - 1
+    end
+    vim.api.nvim_win_set_cursor(self._win_id, { new_line, 1 })
+    self:_render_entries()
+  end
+end
+
+--- Move given or current buffer up in cyclic manner
+---@param buffer? integer
+function UI:move_buffer_down(buffer)
+  self.registry_instance:clean()
+  local registry = self.registry_instance:get_registry()
+  local no_of_buffers = #registry
+  if no_of_buffers == 0 then
+    return
+  end
+  local buf = buffer
+    or (
+      utils.is_floating_window() and vim.api.nvim_win_get_buf(vim.fn.win_getid(vim.fn.winnr("#")))
+      or vim.api.nvim_get_current_buf()
+    )
+  local buf_idx = utils.get_index(registry, buf)
+  if buf_idx == nil then
+    return
+  end
+  self.registry_instance:move_buffer_down(buf_idx, true)
+  if utils.window_exists(self._win_id) then
+    local new_line = 1
+    if buf_idx < no_of_buffers then
+      new_line = buf_idx + 1
+    end
+    vim.api.nvim_win_set_cursor(self._win_id, { new_line, 1 })
+    self:_render_entries()
+  end
+end
+
 return UI:new(require("loft.registry"))

--- a/lua/loft/ui.lua
+++ b/lua/loft/ui.lua
@@ -546,20 +546,17 @@ function UI:smart_order_indicator()
   return is_smart_order_on and self._smart_order_symbol or ""
 end
 
---- Move given or current buffer up in cyclic manner
----@param buffer? integer
-function UI:move_buffer_up(buffer)
+--- Move the current buffer up the registry in cyclic manner while showing the UI briefly
+function UI:move_buffer_up()
   self.registry_instance:clean()
   local registry = self.registry_instance:get_registry()
   local no_of_buffers = #registry
   if no_of_buffers == 0 then
     return
   end
-  local buf = buffer
-    or (
-      utils.is_floating_window() and vim.api.nvim_win_get_buf(vim.fn.win_getid(vim.fn.winnr("#")))
-      or vim.api.nvim_get_current_buf()
-    )
+  local buf = utils.is_floating_window() and vim.api.nvim_win_get_buf(vim.fn.win_getid(vim.fn.winnr("#")))
+    or vim.api.nvim_get_current_buf()
+
   local buf_idx = utils.get_index(registry, buf)
   if buf_idx == nil then
     return
@@ -581,20 +578,16 @@ function UI:move_buffer_up(buffer)
   end
 end
 
---- Move given or current buffer up in cyclic manner
----@param buffer? integer
-function UI:move_buffer_down(buffer)
+--- Move the current buffer down the registry in a cyclic manner while showing the UI briefly
+function UI:move_buffer_down()
   self.registry_instance:clean()
   local registry = self.registry_instance:get_registry()
   local no_of_buffers = #registry
   if no_of_buffers == 0 then
     return
   end
-  local buf = buffer
-    or (
-      utils.is_floating_window() and vim.api.nvim_win_get_buf(vim.fn.win_getid(vim.fn.winnr("#")))
-      or vim.api.nvim_get_current_buf()
-    )
+  local buf = utils.is_floating_window() and vim.api.nvim_win_get_buf(vim.fn.win_getid(vim.fn.winnr("#")))
+    or vim.api.nvim_get_current_buf()
   local buf_idx = utils.get_index(registry, buf)
   if buf_idx == nil then
     return

--- a/lua/loft/ui.lua
+++ b/lua/loft/ui.lua
@@ -541,6 +541,15 @@ function UI:smart_order_indicator()
   return is_smart_order_on and self._smart_order_symbol or ""
 end
 
+---@type fun(self: loft.UI)
+local debounce_close = utils.debounce(
+  ---@param self loft.UI
+  function(self)
+    self:close()
+  end,
+  800
+)
+
 --- Move given or current buffer up in cyclic manner
 ---@param buffer? integer
 function UI:move_buffer_up(buffer)
@@ -559,6 +568,10 @@ function UI:move_buffer_up(buffer)
   if buf_idx == nil then
     return
   end
+  if not utils.window_exists(self._win_id) then
+    self:open()
+  end
+  debounce_close(self)
   self.registry_instance:move_buffer_up(buf_idx, true)
   if utils.window_exists(self._win_id) then
     local new_line = no_of_buffers
@@ -588,6 +601,10 @@ function UI:move_buffer_down(buffer)
   if buf_idx == nil then
     return
   end
+  if not utils.window_exists(self._win_id) then
+    self:open()
+  end
+  debounce_close(self)
   self.registry_instance:move_buffer_down(buf_idx, true)
   if utils.window_exists(self._win_id) then
     local new_line = 1

--- a/lua/loft/ui.lua
+++ b/lua/loft/ui.lua
@@ -345,11 +345,11 @@ end
 
 ---@private
 function UI:_get_footer()
-  return " "
-    .. self._smart_order_symbol
-    .. ": "
-    .. (self.registry_instance:is_smart_order_on() and "ON" or "OFF")
-    .. " "
+  local smart_order_indicator = self:smart_order_indicator()
+  if smart_order_indicator == "" then
+    return ""
+  end
+  return " " .. self:smart_order_indicator() .. " "
 end
 
 ---@param extras string|nil
@@ -544,8 +544,7 @@ end
 --- Get the smart order indicator (string)
 function UI:smart_order_indicator()
   local is_smart_order_on = self.registry_instance:is_smart_order_on()
-  local status = is_smart_order_on and "ON" or "OFF"
-  return self._smart_order_symbol .. ": " .. status
+  return is_smart_order_on and self._smart_order_symbol or ""
 end
 
 return UI:new(require("loft.registry"))


### PR DESCRIPTION
- [x] key binding to  rearrange or move current buffer without opening loft ui [S-M-(i|o)]
- [x] briefly show loft ui after moving current buffer
- [x] replace move current buff with telescope select to using alternate buffer
- [x] add tip in readme about using / to search entries in the Loft UI
- [x] only show smart order icon when it’s on i.e remove the ON/OFF text
- [x] use vim motion to move cursor cyclically